### PR TITLE
rediseño panel de juego

### DIFF
--- a/src/main/java/co/edu/uptc/view/game/GamePanel.java
+++ b/src/main/java/co/edu/uptc/view/game/GamePanel.java
@@ -1,18 +1,25 @@
 package co.edu.uptc.view.game;
 
+import java.awt.Color;
+import java.awt.FlowLayout;
+
+import javax.swing.BoxLayout;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import co.edu.uptc.view.MainPanel;
 import co.edu.uptc.view.game.crupier.CrupierPanel;
-import co.edu.uptc.view.game.players.BottomPanel;
 import co.edu.uptc.view.game.draw.RoundedBorder;
+import co.edu.uptc.view.game.players.BottomPanel;
+import co.edu.uptc.view.game.players.CenterPanel;
 import co.edu.uptc.view.popups.ClosePanel;
 import co.edu.uptc.view.reusable.Constants;
-
-import javax.swing.*;
-import java.awt.*;
 
 public class GamePanel extends JPanel {
     private final MainPanel mainPanel;
     private final CrupierPanel crupierPanel;
+    private final CenterPanel centerPanel;
     private final BottomPanel bottomPanel;
     private final ClosePanel closePanel;
 
@@ -20,10 +27,12 @@ public class GamePanel extends JPanel {
         this.mainPanel = mainPanel;
         closePanel = new ClosePanel(mainPanel);
         crupierPanel = new CrupierPanel(this);
+        centerPanel = new CenterPanel();
         bottomPanel = new BottomPanel();
         setLayout(new BoxLayout(this, BoxLayout.Y_AXIS));
         add(crupierPanel);
         addDecorations();
+        add(centerPanel);
         add(bottomPanel);
         setOpaque(false);
     }

--- a/src/main/java/co/edu/uptc/view/game/players/ActionsPanel.java
+++ b/src/main/java/co/edu/uptc/view/game/players/ActionsPanel.java
@@ -1,9 +1,15 @@
 package co.edu.uptc.view.game.players;
 
-import co.edu.uptc.view.reusable.ImageButton;
+import java.awt.Color;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
 
-import java.awt.*;
-import javax.swing.*;
+import javax.swing.BorderFactory;
+import javax.swing.JButton;
+import javax.swing.JPanel;
+
+import co.edu.uptc.view.reusable.ImageButton;
 
 public class ActionsPanel extends JPanel {
     private JPanel firstLine, secondLine, thirdLine;
@@ -52,8 +58,8 @@ public class ActionsPanel extends JPanel {
     }
 
     public void addLinesToPanel() {
-        gbc.gridwidth = GridBagConstraints.REMAINDER;
         add(firstLine,gbc);
+        gbc.gridwidth = GridBagConstraints.REMAINDER;
         add(secondLine,gbc);
         add(thirdLine,gbc);
     }
@@ -71,8 +77,8 @@ public class ActionsPanel extends JPanel {
         ask = new ImageButton("Pedir", false, 10);
         doblar = new ImageButton("Doblar", false, 10);
         quit = new ImageButton("Rendirse", false, 10);
-        settle = new ImageButton("Quedarse", true, 10);
-        divide = new ImageButton("Dividir", true, 10);
+        settle = new ImageButton("Quedarse", false, 10);
+        divide = new ImageButton("Dividir", false, 10);
 
         tokens = new TokensPanel();
     }

--- a/src/main/java/co/edu/uptc/view/game/players/BottomPanel.java
+++ b/src/main/java/co/edu/uptc/view/game/players/BottomPanel.java
@@ -1,79 +1,26 @@
 package co.edu.uptc.view.game.players;
 
-import javax.swing.*;
-import java.awt.*;
+import java.awt.FlowLayout;
 
-public class BottomPanel extends JPanel {
+import javax.swing.JPanel;
 
-    private GridBagConstraints gbc;
-    private PlayerPanel leftPlayerPanel, centerPlayerPanel, rightPlayerPanel;
-    private JPanel playerTokens;
-    private ActionsPanel actionsPanel;
+public class BottomPanel extends JPanel{
+    
+    private final ActionsPanel actionsPanel;
 
     public BottomPanel() {
-        setOpaque(false);
-        setBorder(BorderFactory.createLineBorder(Color.RED));
-        setLayout(new GridBagLayout());
-        gbc = new GridBagConstraints();
-
-        initComponents();
-        firstLine();
+        this.actionsPanel = new ActionsPanel();
+        this.setOpaque(false);
+        initcomponents();
+        addComponents();
     }
 
-    private void initComponents() {
-        playerTokens = new TokensPanel();
-        actionsPanel = new ActionsPanel();
+    private void initcomponents(){
+        this.setLayout(new FlowLayout());
 
-        leftPlayerPanel = new PlayerPanel("Waiting...");
-        leftPlayerPanel.setBorder(BorderFactory.createLineBorder(Color.RED));
-
-        centerPlayerPanel = new PlayerPanel("Waiting...");
-        centerPlayerPanel.setBorder(BorderFactory.createLineBorder(Color.RED));
-        centerPlayerPanel.addCard(0,1);
-        centerPlayerPanel.addCard(1,1);
-
-        rightPlayerPanel = new PlayerPanel("Waiting...");
-        rightPlayerPanel.setBorder(BorderFactory.createLineBorder(Color.RED));
-        rightPlayerPanel.addCard(0,2);
-        rightPlayerPanel.addCard(1,2);
-        rightPlayerPanel.addCard(2,2);
-
-        leftPlayerPanel.setOpaque(false);
-        centerPlayerPanel.setOpaque(false);
-        rightPlayerPanel.setOpaque(false);
     }
 
-    private void firstLine() {
-        gbc.gridx = 1;
-        gbc.gridy = 0;
-        add(leftPlayerPanel, gbc);
-
-        gbc.gridx = 2;
-        add(centerPlayerPanel, gbc);
-
-        gbc.gridx = 3;
-        add(rightPlayerPanel, gbc);
-        gbc.gridwidth = 1;
-        gbc.ipady = 10;
-
-        secondLine();
-    }
-
-    private void secondLine() {
-        gbc.gridx = 0;
-        gbc.gridy = 1;
-        gbc.gridwidth = 2;
-
-        gbc.insets = new Insets(20, 10, 0, 10);
-        gbc.anchor = GridBagConstraints.LAST_LINE_START;
-
-        add(actionsPanel, gbc);
-
-        gbc.ipady = 0;
-        gbc.gridx = 3;
-
-        gbc.anchor = GridBagConstraints.LAST_LINE_END;
-
-        add(playerTokens, gbc);
+    private void addComponents(){
+        this.add(actionsPanel);
     }
 }

--- a/src/main/java/co/edu/uptc/view/game/players/CenterPanel.java
+++ b/src/main/java/co/edu/uptc/view/game/players/CenterPanel.java
@@ -1,0 +1,63 @@
+package co.edu.uptc.view.game.players;
+
+import java.awt.Color;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+
+import javax.swing.BorderFactory;
+import javax.swing.JPanel;
+
+public class CenterPanel extends JPanel {
+
+    private GridBagConstraints gbc;
+    private PlayerPanel leftPlayerPanel, centerPlayerPanel, rightPlayerPanel;
+
+    public CenterPanel() {
+        setOpaque(false);
+        setBorder(BorderFactory.createLineBorder(Color.RED));
+        setLayout(new GridBagLayout());
+        gbc = new GridBagConstraints();
+
+        initComponents();
+        firstLine();
+    }
+
+    private void initComponents() {
+        leftPlayerPanel = new PlayerPanel("Waiting...");
+        leftPlayerPanel.setBorder(BorderFactory.createLineBorder(Color.RED));
+        leftPlayerPanel.addCard(0, 1);
+        leftPlayerPanel.addCard(0, 3);
+        leftPlayerPanel.addCard(0, 3);
+
+        centerPlayerPanel = new PlayerPanel("Waiting...");
+        centerPlayerPanel.setBorder(BorderFactory.createLineBorder(Color.RED));
+        centerPlayerPanel.addCard(0,1);
+        centerPlayerPanel.addCard(1,1);
+        centerPlayerPanel.addCard(1,1);
+
+        rightPlayerPanel = new PlayerPanel("Waiting...");
+        rightPlayerPanel.setBorder(BorderFactory.createLineBorder(Color.RED));
+        rightPlayerPanel.addCard(0,2);
+        rightPlayerPanel.addCard(1,2);
+        rightPlayerPanel.addCard(2,2);
+
+        leftPlayerPanel.setOpaque(false);
+        centerPlayerPanel.setOpaque(false);
+        rightPlayerPanel.setOpaque(false);
+    }
+
+    private void firstLine() {
+        gbc.gridx = 1;
+        gbc.gridy = 0;
+        add(leftPlayerPanel, gbc);
+
+        gbc.gridx = 2;
+        add(centerPlayerPanel, gbc);
+
+        gbc.gridx = 3;
+        add(rightPlayerPanel, gbc);
+        gbc.gridwidth = 1;
+        gbc.ipady = 10;
+
+    }
+}

--- a/src/main/java/co/edu/uptc/view/game/players/PlayerPanel.java
+++ b/src/main/java/co/edu/uptc/view/game/players/PlayerPanel.java
@@ -1,20 +1,30 @@
 package co.edu.uptc.view.game.players;
 
+import java.awt.Color;
+import java.awt.Component;
+import java.awt.GridBagConstraints;
+import java.awt.GridBagLayout;
+import java.awt.Insets;
+
+import javax.swing.BorderFactory;
+import javax.swing.JLabel;
+import javax.swing.JPanel;
+import javax.swing.SwingConstants;
+
 import co.edu.uptc.view.game.CardsPanel;
 import co.edu.uptc.view.game.GameConstants;
 import co.edu.uptc.view.reusable.Constants;
-
-import javax.swing.*;
-import java.awt.*;
 
 public class PlayerPanel extends JPanel {
     private final JLabel name;
     private final CardsPanel cardsPanel;
     private final GridBagConstraints gbc = new GridBagConstraints();
+    private final TokensPanel betTokens;
 
     public PlayerPanel(String name) {
         setBorder(BorderFactory.createLineBorder(Color.RED));
         this.name = new JLabel(name);
+        betTokens = new TokensPanel();
         cardsPanel = new CardsPanel(GameConstants.PLAYER_CARDS_DIMENSION);
 
         initComponents();
@@ -22,9 +32,11 @@ public class PlayerPanel extends JPanel {
     }
 
     public final void initComponents() {
+
         setLayout(new GridBagLayout());
         setOpaque(false);
         setAlignmentY(Component.TOP_ALIGNMENT);
+
 
         name.setFont(Constants.CUSTOM_FONT.deriveFont(10f));
         name.setBackground(new Color(49,41,41,255));
@@ -35,12 +47,17 @@ public class PlayerPanel extends JPanel {
     }
 
     public final void addComponents() {
-        gbc.gridy = 0;
+
+         gbc.gridy = 0;
+         
+        add(betTokens,gbc);
+
+        gbc.gridy = 1;
         gbc.ipady = 50;
         gbc.ipadx = 180;
         add(cardsPanel, gbc);
 
-        gbc.gridy = 1;
+        gbc.gridy = 2;
         gbc.ipadx = 30;
         gbc.ipady = 30;
         gbc.insets = new Insets(10, 0, 0, 0);

--- a/src/main/java/co/edu/uptc/view/reusable/ImageButton.java
+++ b/src/main/java/co/edu/uptc/view/reusable/ImageButton.java
@@ -113,7 +113,7 @@ public class ImageButton extends JButton {
     }
 
     private BufferedImage createSolidColorImage(boolean pressed) {
-        BufferedImage image = new BufferedImage(100, 50, BufferedImage.TYPE_INT_ARGB);
+        BufferedImage image = new BufferedImage(200, 50, BufferedImage.TYPE_INT_ARGB);
         Graphics g = image.getGraphics();
         if (textColor.equals(Constants.PRIMARY_BUTTON_COLOR)) {
             g.setColor(Constants.SECONDARY_BUTTON_COLOR);


### PR DESCRIPTION
Se centro el panel de acciones, se retiro las fichas apostadas y se las agrego arriba de las cartas de cada jugador. Se cambiaron de dos filas a una única fila de botones en el panel de acciones, se cambiaron los botones de este mismo panel para que sean iguales. Lo que era BottomPanel el cual contenía los paneles de los jugadores y el panel de acciones se renombro como CenterPanel, donde se le retiro el panel de acciones, se creo una nueva clase que se llama BottomPanel la cual contiene el panel de acciones, y se agrego de forma separada al panel donde estaban los paneles de los jugadores. Esto porque los paneles de los jugadores se veían afectados al cambiar el largo del panel de acciones, así que opté por agregarlo como panel independiente (BottomPanel) para que no se vieran afectados los paneles de los jugadores.